### PR TITLE
Add homebrew support for osx installation

### DIFF
--- a/HomebrewFormula/kctl.rb
+++ b/HomebrewFormula/kctl.rb
@@ -1,0 +1,10 @@
+class Kctl < Formula
+  desc "A CLI wrapper for making kubernetes commands much easier"
+  homepage "https://github.com/alaminopu/kctl"
+  url "https://github.com/dnivra26/kctl/releases/download/0.1.4/kctl-0.1.4-x86_64-darwin.tar.gz"
+  sha256 "5bd5558d2488023ab3f55a77606de1d75305e7a1cf7c0e2a321026e7ca66e781"
+
+  def install
+    bin.install "kctl"
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,13 @@ You will find the binary in /target folder
 
 
 ## Installation
+Homebrew  
+```
+brew tap alaminopu/kctl https://github.com/alaminopu/kctl.git  
+brew install kctl
+```
 
+Manual
 ```
 chmod a+x kctl
 ```


### PR DESCRIPTION
The homebrew formula is inside the `HomebrewFormula` directory.
The URL in the ruby file refers to my repo for now because the binary is not available in your repo. Once it is available we can update the URL.
Have also updated readme with instructions.
Tested on my machine with minikube.